### PR TITLE
Add StyleCop Code Analysis configuration

### DIFF
--- a/TheBereftSouls.csproj
+++ b/TheBereftSouls.csproj
@@ -1,16 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<!-- Import tModLoader mod properties -->
-	<Import Project="..\tModLoader.targets" />
+    <!-- Import tModLoader mod properties -->
+    <Import Project="..\tModLoader.targets" />
 
-	<!-- General -->
-	<PropertyGroup>
-		
-	</PropertyGroup>
+    <!-- General -->
+    <PropertyGroup>
+        <!--
+        SA0001 - All diagnostics of XML documentation comments has been
+                 disabled due to the current project configuration.
+                   - https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
+        SA1633 - A C# code file is missing a standard file header.
+                   - https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+        -->
+        <NoWarn>SA0001,SA1633</NoWarn>
+    </PropertyGroup>
 
-	<!-- References -->
-	<ItemGroup>
-		
-	</ItemGroup>
+    <!-- References -->
+    <ItemGroup>
+        <AdditionalFiles Include="stylecop.json" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
 
 </Project>

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "orderingRules": {
+      "usingDirectivesPlacement": "preserve"
+    }
+  }
+}


### PR DESCRIPTION
## Reason

As the codebase grows larger we'll need to reinforce code standards and [StyleCop](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/ "GitHub repo source") in order to make the codebase more readable and easier to navigate by everyone.

To run the code analyzer you need to do the following:

```sh
dotnet build --no-incremental
```

> [!NOTE]
> I recommend using the `--no-incremental` flag because with incremental compilation it doesn't catch any warnings for me. 

---

> [!IMPORTANT]
> As much as I'd love to have a CI/CD implementation, the `.csproj` file relies on Terraria `.dll` files so it's not feasible to automate this process, making reinforcing code standards a task for the reviewers and maintainers of the pull requests.