### PR TITLE
use properties and readonly fields as neccesary. fix some warnings.

### DIFF
--- a/Common/Systems/KeyBindSystem.cs
+++ b/Common/Systems/KeyBindSystem.cs
@@ -4,7 +4,7 @@ namespace TheBereftSouls.Common.Systems
 {
     public class KeybindSystem : ModSystem
     {
-        public static ModKeybind VesperaEnchStone;
+        public static ModKeybind VesperaEnchStone { get; private set; }
 
         public override void Load()
         {

--- a/Content/BootRecipes.cs
+++ b/Content/BootRecipes.cs
@@ -37,7 +37,7 @@ namespace TheBereftSouls.Content
                         break;
                     default:
                         break;
-                };
+                }
             }
         }
     }

--- a/Content/Items/Accessories/FrigidEnchantment.cs
+++ b/Content/Items/Accessories/FrigidEnchantment.cs
@@ -11,9 +11,9 @@ namespace TheBereftSouls.Content.Items.Accessories
     [ExtendsFromMod("SOTS")]
     public class FrigidEnchantment : ModItem
     {
-        public static int PercentDamage = 10;
-        public static int FlatDamage = 10;
-        public static int Crit = 5;
+        public static readonly int PercentDamage = 10;
+        public static readonly int FlatDamage = 10;
+        public static readonly int Crit = 5;
 
         public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(PercentDamage, FlatDamage, Crit);
 

--- a/Content/Items/Accessories/FrigidEnchantment.cs
+++ b/Content/Items/Accessories/FrigidEnchantment.cs
@@ -11,11 +11,11 @@ namespace TheBereftSouls.Content.Items.Accessories
     [ExtendsFromMod("SOTS")]
     public class FrigidEnchantment : ModItem
     {
-        public const int PRECENT_DAMAGE = 10;
+        public const int PERCENT_DAMAGE = 10;
         public const int FLAT_DAMAGE = 10;
         public const int CRIT = 5;
 
-        public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(PRECENT_DAMAGE, FLAT_DAMAGE, CRIT);
+        public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(PERCENT_DAMAGE, FLAT_DAMAGE, CRIT);
 
         public override void SetStaticDefaults()
         {
@@ -67,7 +67,7 @@ namespace TheBereftSouls.Content.Items.Accessories
         {
             if (player.GetModPlayer<BereftSOTSPlayer>().FrigidEnch)
             {
-                damage += FrigidEnchantment.PRECENT_DAMAGE / 100;
+                damage += FrigidEnchantment.PERCENT_DAMAGE / 100;
                 damage.Flat += FrigidEnchantment.FLAT_DAMAGE;
             }
         }

--- a/Content/Items/Accessories/FrigidEnchantment.cs
+++ b/Content/Items/Accessories/FrigidEnchantment.cs
@@ -11,11 +11,11 @@ namespace TheBereftSouls.Content.Items.Accessories
     [ExtendsFromMod("SOTS")]
     public class FrigidEnchantment : ModItem
     {
-        public static readonly int PercentDamage = 10;
-        public static readonly int FlatDamage = 10;
-        public static readonly int Crit = 5;
+        public const int PRECENT_DAMAGE = 10;
+        public const int FLAT_DAMAGE = 10;
+        public const int CRIT = 5;
 
-        public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(PercentDamage, FlatDamage, Crit);
+        public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(PRECENT_DAMAGE, FLAT_DAMAGE, CRIT);
 
         public override void SetStaticDefaults()
         {
@@ -67,8 +67,8 @@ namespace TheBereftSouls.Content.Items.Accessories
         {
             if (player.GetModPlayer<BereftSOTSPlayer>().FrigidEnch)
             {
-                damage += FrigidEnchantment.PercentDamage / 100;
-                damage.Flat += FrigidEnchantment.FlatDamage;
+                damage += FrigidEnchantment.PRECENT_DAMAGE / 100;
+                damage.Flat += FrigidEnchantment.FLAT_DAMAGE;
             }
         }
 
@@ -76,7 +76,7 @@ namespace TheBereftSouls.Content.Items.Accessories
         {
             if (player.GetModPlayer<BereftSOTSPlayer>().FrigidEnch)
             {
-                crit += FrigidEnchantment.Crit;
+                crit += FrigidEnchantment.CRIT;
             }
         }
     }

--- a/Content/Items/Accessories/VibrantEnchantment.cs
+++ b/Content/Items/Accessories/VibrantEnchantment.cs
@@ -51,9 +51,9 @@ namespace TheBereftSouls.Content.Items.Accessories
     [ExtendsFromMod("SOTS")]
     public class VibrantItem : GlobalItem
     {
-        public override bool InstancePerEntity => true;
-
         private float chanceToFire = 0.8f; // 80% chance to shoot
+
+        public override bool InstancePerEntity => true;
 
         public override bool Shoot(Item item, Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {

--- a/Content/Items/Accessories/WormwoodEnchantment.cs
+++ b/Content/Items/Accessories/WormwoodEnchantment.cs
@@ -14,12 +14,11 @@ namespace TheBereftSouls.Content.Items.Accessories
     [ExtendsFromMod("SOTS")]
     public class WormwoodEnchantment : ModItem
     {
-        public List<Projectile> Hooks = new List<Projectile>(hooksToSummon);
+        private static readonly int DefenseBoost = 1;
+        private static readonly int HooksToSummon = 4;
+        private readonly List<Projectile> hooks = new(HooksToSummon);
 
-        public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(defenseBoost);
-
-        private static int defenseBoost = 1;
-        private static int hooksToSummon = 4;
+        public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(DefenseBoost);
 
         public override void SetStaticDefaults()
         {
@@ -37,25 +36,25 @@ namespace TheBereftSouls.Content.Items.Accessories
 
         public override void UpdateAccessory(Player player, bool hideVisual)
         {
-            player.statDefense += player.numMinions * defenseBoost;
+            player.statDefense += player.numMinions * DefenseBoost;
             if (Main.myPlayer == player.whoAmI)
             {
                 if (!player.HasBuff(ModContent.BuffType<PatchedUpDebuff>()) && player.statLife > player.statLifeMax2 / 2)
                 {
-                    if (Hooks.Count < hooksToSummon)
+                    if (hooks.Count < HooksToSummon)
                     {
-                        Hooks.Add(Projectile.NewProjectileDirect(player.GetSource_FromThis(), player.MountedCenter, Vector2.Zero, ModContent.ProjectileType<BloomingHook>(), 11, 1));
+                        hooks.Add(Projectile.NewProjectileDirect(player.GetSource_FromThis(), player.MountedCenter, Vector2.Zero, ModContent.ProjectileType<BloomingHook>(), 11, 1));
                     }
                 }
 
-                foreach (var hook in Hooks)
+                foreach (var hook in hooks)
                 {
                     hook.timeLeft = 6;
                 }
 
                 if (player.statLife < player.statLifeMax / 2)
                 {
-                    foreach (var hook in Hooks)
+                    foreach (var hook in hooks)
                     {
                         hook.Kill();
                         player.Heal(player.statLifeMax2 / 16);
@@ -63,12 +62,12 @@ namespace TheBereftSouls.Content.Items.Accessories
                         BereftUtils.DustCircle(player.Center, 16, 10, DustID.GemEmerald, Main.rand.NextFloat(1f, 2f));
                     }
 
-                    Hooks.Clear();
+                    hooks.Clear();
                 }
 
-                if (Hooks.Count > 0 && !Hooks[0].active)
+                if (hooks.Count > 0 && !hooks[0].active)
                 {
-                    Hooks.Clear();
+                    hooks.Clear();
                 }
             }
         }

--- a/Content/Items/Accessories/WormwoodEnchantment.cs
+++ b/Content/Items/Accessories/WormwoodEnchantment.cs
@@ -14,11 +14,11 @@ namespace TheBereftSouls.Content.Items.Accessories
     [ExtendsFromMod("SOTS")]
     public class WormwoodEnchantment : ModItem
     {
-        private static readonly int DefenseBoost = 1;
-        private static readonly int HooksToSummon = 4;
-        private readonly List<Projectile> hooks = new(HooksToSummon);
+        private const int DEFENSE_BOOST = 1;
+        private const int HOOKS_TO_SUMMON = 4;
+        private readonly List<Projectile> hooks = new(HOOKS_TO_SUMMON);
 
-        public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(DefenseBoost);
+        public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(DEFENSE_BOOST);
 
         public override void SetStaticDefaults()
         {
@@ -36,12 +36,12 @@ namespace TheBereftSouls.Content.Items.Accessories
 
         public override void UpdateAccessory(Player player, bool hideVisual)
         {
-            player.statDefense += player.numMinions * DefenseBoost;
+            player.statDefense += player.numMinions * DEFENSE_BOOST;
             if (Main.myPlayer == player.whoAmI)
             {
                 if (!player.HasBuff(ModContent.BuffType<PatchedUpDebuff>()) && player.statLife > player.statLifeMax2 / 2)
                 {
-                    if (hooks.Count < HooksToSummon)
+                    if (hooks.Count < HOOKS_TO_SUMMON)
                     {
                         hooks.Add(Projectile.NewProjectileDirect(player.GetSource_FromThis(), player.MountedCenter, Vector2.Zero, ModContent.ProjectileType<BloomingHook>(), 11, 1));
                     }

--- a/Players/BereftSOTSPlayer.cs
+++ b/Players/BereftSOTSPlayer.cs
@@ -11,12 +11,9 @@ namespace TheBereftSouls.Players
     [ExtendsFromMod("SOTS")]
     public class BereftSOTSPlayer : ModPlayer
     {
-        public bool VibrantEnch = false;
-        public bool FrigidEnch = false;
-
-        public List<Vector2> VesperaStoneCoords = new List<Vector2>(); // Used by Vespera ench
-        public static List<int> FrigidItems = new List<int>() // Used by Frigid Ench, needs to be updated with weapons from other mods; Maybe move somewhere else
-        {
+        // Used by Frigid Ench, needs to be updated with weapons from other mods; Maybe move somewhere else
+        public static HashSet<int> FrigidItems { get; } =
+        [
             ItemID.Snowball,
             ItemID.SnowballCannon,
             ItemID.SnowmanCannon,
@@ -45,9 +42,14 @@ namespace TheBereftSouls.Players
             ModContent.ItemType<Metalmalgamation>(),
             ModContent.ItemType<ShardstormSpell>(),
             ModContent.ItemType<NorthStar>(),
-        };
+        ];
 
-        public bool PatchedUp = false;
+        public bool VibrantEnch { get; set; } = false;
+        public bool FrigidEnch { get; set; } = false;
+        public bool PatchedUp { get; set; } = false;
+
+        // Used by Vespera ench
+        public List<Vector2> VesperaStoneCoords { get; } = [];
 
         public override void ResetEffects()
         {


### PR DESCRIPTION
warnings from 101 to 89
but really we should replace this stylecop with a simple `.editorconfig`

also makes FrigidItems a hashset

