### PR TITLE
update .editorconfig to warn if block-scoped namespaces are used

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,3 @@
 [*.cs]
 end_of_line = lf
+csharp_style_namespace_declarations = file_scoped:warning


### PR DESCRIPTION
(block-scoped is the opposite of file-scoped)